### PR TITLE
docs: fix simple typo, seperate -> separate

### DIFF
--- a/pipe_util.h
+++ b/pipe_util.h
@@ -91,7 +91,7 @@ pipeline_t pipe_parallel(size_t           instances,
 /*
  * A pipeline consists of a list of functions and pipes. As data is recieved in
  * one end, it is processed by each of the pipes and pushed into the other end.
- * Each stage's processing is done in a seperate thread. The last parameter must
+ * Each stage's processing is done in a separate thread. The last parameter must
  * be NULL (in place of a pipe_processor_t) if you want to have a consumer_t
  * returned, or 0 (in place of a sizeof()) if you don't want or need a consumer_t.
  * If the last parameter replaces a sizeof(), the return value's `c' member will


### PR DESCRIPTION
There is a small typo in pipe_util.h.

Should read `separate` rather than `seperate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md